### PR TITLE
Handle peer dependencies correctly

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,3 @@
 export const ES6_IMPORT_STATEMENT = /import [{}\w\s,]+ from ['"]([\w@/]+)['"]/g
 export const REQUIRE_IMPORT_STATEMENT = /(?:const|var|let) [ {}\w]+ = require\(['"]([\w@/]+)['"]\)/g
-export const SOURCE_FILE_PATTERN = /[\w.\- ]+\.[tj]sx?$/
+export const SOURCE_FILE_PATTERN = /[\w.\- ]+(?<![jt]est)\.[tj]sx?$/

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,3 @@
-export const ES6_IMPORT_STATEMENT = /import [{}\w\s,]+ from ['"]([\w@/]+)['"]/g
-export const REQUIRE_IMPORT_STATEMENT = /(?:const|var|let) [ {}\w]+ = require\(['"]([\w@/]+)['"]\)/g
+export const ES6_IMPORT_STATEMENT = /import [{}\w\s,]+ from ['"]([\w@/-]+)['"]/g
+export const REQUIRE_IMPORT_STATEMENT = /(?:const|var|let) [ {}\w]+ = require\(['"]([\w@/-]+)['"]\)/g
 export const SOURCE_FILE_PATTERN = /[\w.\- ]+(?<![jt]est)\.[tj]sx?$/

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -4,3 +4,18 @@ export function isValidSourceFile(path: string): boolean {
     const pattern = SOURCE_FILE_PATTERN
     return pattern.test(path)
 }
+
+export function isPartialMatch(left: string, right: string): boolean {
+    const prefixPattern = new RegExp(`^${left}`)
+    return prefixPattern.test(right)
+}
+
+/*
+export function isBuiltIn(packageName: string): boolean {
+    try {
+        return !require.resolve(packageName).includes('node_modules')
+    } catch (e) {
+        console.log(e)
+        return false
+    }
+}*/

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -6,7 +6,7 @@ export function isValidSourceFile(path: string): boolean {
 }
 
 export function isPartialMatch(left: string, right: string): boolean {
-    const prefixPattern = new RegExp(`^${left}`)
+    const prefixPattern = new RegExp(`^${left}/`)
     return prefixPattern.test(right)
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,13 +9,18 @@ import {
 import parseCliArgs from './cli'
 
 function validateDependencies(projectPath: string): void {
-    const declaredDependencies = extractDeclaredDependencies(projectPath)
+    const {
+        dependencies = [],
+        peerDependencies = [],
+    } = extractDeclaredDependencies(projectPath)
     const sourceFiles = discoverSourceFiles(projectPath)
     const importedDependencies = getImportsFromFiles(sourceFiles)
 
     const { left: unused, right: undeclared } = diffDependenciesLists(
-        declaredDependencies,
+        dependencies,
         importedDependencies,
+        (packageName: string): boolean =>
+            !peerDependencies.includes(packageName),
     )
 
     if (unused.length === 0)

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -12,9 +12,9 @@ export interface PackageConfig {
 }
 
 export interface PackageDependencies {
-    dependencies: string[]
-    devDependencies: string[]
-    peerDependencies: string[]
+    dependencies?: string[]
+    devDependencies?: string[]
+    peerDependencies?: string[]
 }
 
 export interface DiffReport {

--- a/src/useCases.test.ts
+++ b/src/useCases.test.ts
@@ -65,12 +65,12 @@ describe('Use cases', () => {
     })
 
     describe('Dependencies list diffing', () => {
+        beforeEach(mockFS.restore)
         it('correctly diffs', () => {
             const left = ['yeet', 'dang', 'sticks']
             const right = ['yeet', 'yeetas']
 
             const diffReport = diffDependenciesLists(left, right)
-
             expect(diffReport.left).toEqual(['dang', 'sticks'])
             expect(diffReport.right).toEqual(['yeetas'])
             expect(diffReport.union).toEqual(['yeet'])
@@ -85,6 +85,17 @@ describe('Use cases', () => {
 
             expect(diffReport.left).toEqual(['dang', 'sticks'])
             expect(diffReport.right).toEqual([])
+            expect(diffReport.union).toEqual([])
+        })
+
+        it('filters out partial matches in either set', () => {
+            const left = ['yeet', 'yoot/get']
+            const right = ['yoot', 'yeet/put']
+
+            const diffReport = diffDependenciesLists(left, right)
+
+            expect(diffReport.left).toEqual(['yeet'])
+            expect(diffReport.right).toEqual(['yoot'])
             expect(diffReport.union).toEqual([])
         })
     })
@@ -119,7 +130,22 @@ describe('Use cases', () => {
 
             const extracted = extractDeclaredDependencies()
 
-            expect(extracted).toEqual(Object.keys(mockPackageJSON.dependencies))
+            expect(extracted).toEqual({
+                dependencies: Object.keys(mockPackageJSON.dependencies),
+                peerDependencies: [],
+            })
+        })
+
+        it('uses defaults if there are no dependencies or peer dependencies', () => {
+            mockFS({
+                'package.json': '{}',
+            })
+
+            const extracted = extractDeclaredDependencies('.')
+            expect(extracted).toEqual({
+                dependencies: [],
+                peerDependencies: [],
+            })
         })
 
         it('works', () => {
@@ -136,7 +162,10 @@ describe('Use cases', () => {
 
             const extracted = extractDeclaredDependencies('.')
 
-            expect(extracted).toEqual(Object.keys(mockPackageJSON.dependencies))
+            expect(extracted).toEqual({
+                dependencies: Object.keys(mockPackageJSON.dependencies),
+                peerDependencies: [],
+            })
         })
 
         it('errors', () => {
@@ -144,7 +173,10 @@ describe('Use cases', () => {
 
             const extracted = extractDeclaredDependencies('.')
 
-            expect(extracted).toEqual([])
+            expect(extracted).toEqual({
+                dependencies: [],
+                peerDependencies: [],
+            })
         })
     })
 })

--- a/src/useCases.ts
+++ b/src/useCases.ts
@@ -99,20 +99,18 @@ export function diffDependenciesLists(
         reportBase,
     )
 
-    // TODO: Review this, it's like O(2*N^2)
     const rightWithoutPartialMatches = right.filter(
         (packageName: string): boolean => {
-            return left.some((otherPackage: string): boolean =>
-                isPartialMatch(packageName, otherPackage),
+            return !left.some((otherPackage: string): boolean =>
+                isPartialMatch(otherPackage, packageName),
             )
         },
     )
 
     const leftWithoutPartialMatches = left.filter(
         (packageName: string): boolean => {
-            return rightWithoutPartialMatches.some(
-                (otherPackage: string): boolean =>
-                    isPartialMatch(packageName, otherPackage),
+            return !right.some((otherPackage: string): boolean =>
+                isPartialMatch(otherPackage, packageName),
             )
         },
     )

--- a/src/useCases.ts
+++ b/src/useCases.ts
@@ -1,18 +1,25 @@
 import { lstatSync, readFileSync, readdirSync } from 'fs'
 
-import { DiffReport } from './types.d'
+import { DiffReport, PackageDependencies } from './types.d'
 import { ES6_IMPORT_STATEMENT, REQUIRE_IMPORT_STATEMENT } from './constants'
-import { isValidSourceFile } from './helpers'
+import { isPartialMatch, isValidSourceFile } from './helpers'
 
-export function extractDeclaredDependencies(packagePath = '.'): string[] {
+export function extractDeclaredDependencies(
+    packagePath = '.',
+): PackageDependencies {
     try {
         const packageFile = readFileSync(`${packagePath}/package.json`, {
             encoding: 'utf-8',
         })
         const parsedPackageFile = JSON.parse(packageFile)
-        return Object.keys(parsedPackageFile.dependencies)
+        return {
+            dependencies: Object.keys(parsedPackageFile.dependencies || {}),
+            peerDependencies: Object.keys(
+                parsedPackageFile.peerDependencies || {},
+            ),
+        }
     } catch (e) {
-        return []
+        return { dependencies: [], peerDependencies: [] }
     }
 }
 
@@ -65,19 +72,19 @@ export function getImportsFromFiles(paths: string[]): string[] {
 }
 
 export function diffDependenciesLists(
-    left: string[],
-    right: string[],
+    leftSet: string[],
+    rightSet: string[],
     filter: Function = (): boolean => true,
 ): DiffReport {
-    const unionSet = new Set([...left, ...right])
+    const unionSet = new Set([...leftSet, ...rightSet])
     const reduceHandler = function(
         report: DiffReport,
         current: string,
     ): DiffReport {
         if (!filter(current)) return report
 
-        const inLeft = left.includes(current)
-        const inRight = right.includes(current)
+        const inLeft = leftSet.includes(current)
+        const inRight = rightSet.includes(current)
 
         if (inLeft && !inRight) report.left.push(current)
         if (inRight && !inLeft) report.right.push(current)
@@ -87,15 +94,31 @@ export function diffDependenciesLists(
     }
 
     const reportBase = { left: [], right: [], union: [] }
-    return Array.from(unionSet).reduce(reduceHandler, reportBase)
-}
+    const { left, right, union } = Array.from(unionSet).reduce(
+        reduceHandler,
+        reportBase,
+    )
 
-/*
-export function isBuiltIn(packageName: string): boolean {
-    try {
-        return !require.resolve(packageName).includes('node_modules')
-    } catch (e) {
-        console.log(e)
-        return false
+    // TODO: Review this, it's like O(2*N^2)
+    const rightWithoutPartialMatches = right.filter(
+        (packageName: string): boolean => {
+            return left.some((otherPackage: string): boolean =>
+                isPartialMatch(packageName, otherPackage),
+            )
+        },
+    )
+
+    const leftWithoutPartialMatches = left.filter(
+        (packageName: string): boolean => {
+            return rightWithoutPartialMatches.some(
+                (otherPackage: string): boolean =>
+                    isPartialMatch(packageName, otherPackage),
+            )
+        },
+    )
+    return {
+        left: leftWithoutPartialMatches,
+        right: rightWithoutPartialMatches,
+        union,
     }
-}*/
+}


### PR DESCRIPTION
This PR tackles two issues:
- Peer dependencies should not have the expectation of being imported anywhere. For instance, `core-js` may be a peer dependency, but its presence is enough to make things work.
- Packages like `lodash` can be declared as `lodash` but imported as `lodash/get` because of savvy code-splitting. `lodash/get` should be recognized as a part of `lodash` and not trigger a "declared but not imported" warning.

Partial matching is currently moderately inefficient (it has to do an N^2 check on the dependency lists that result from diffing the imported and declared packages). This could be better.