### PR TITLE
feat: try to resolve what node sees

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ You can pass in parameters to the ghost import call to customize the analysis:
 |`exclude`|`string`|Glob to filter files to exclude when looking for imports. Same usage as `include`|
 |`fix`|`boolean`|When set, unused dependencies are removed and undeclared ones, added. This adds `latest` if available.|
 
+## Autofixing
+
+By default, `ghost-imports-buster` will attempt to resolve undeclared packages the (loosely) same way [node's `require` will](https://nodejs.org/api/modules.html#modules_all_together): by crawling from the current working directory and checking in every `node_modules` in its path to the file system root. If a package cannot be resolved, the `latest` from the registry will be used instead.
+
 ## Contributing
 
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,5 +8,6 @@ module.exports = {
         '^.+\\.(ts|tsx)?$': 'babel-jest',
     },
     collectCoverage: true,
+    collectCoverageFrom: ['src/**/*.ts'],
     coverageDirectory: './coverage',
 }

--- a/src/fixWorkspaces.ts
+++ b/src/fixWorkspaces.ts
@@ -25,7 +25,7 @@ export default async function fixWorkspaces(
                 if (!workspaceName) throw new Error('MISSING_WORKSPACE_NAME')
 
                 const workspaceIdent = structUtils.stringifyIdent(workspaceName)
-                fixWorkspace(
+                await fixWorkspace(
                     context,
                     workspace,
                     resolvedVersionsFromNodeModules,

--- a/src/fixWorkspaces.ts
+++ b/src/fixWorkspaces.ts
@@ -1,14 +1,21 @@
-import { IdentHash, Workspace, structUtils } from '@yarnpkg/core'
+import path from 'path'
+import { promises as fs } from 'fs'
+
+import { IdentHash, Manifest, Workspace, structUtils } from '@yarnpkg/core'
+import { PortablePath } from '@yarnpkg/fslib'
 import { npmHttpUtils } from '@yarnpkg/plugin-npm'
 import chalk from 'chalk'
 
-import { Context, DiffReport } from './types'
+import { Context, DiffReport, PackageResolutions } from './types'
 
 export default async function fixWorkspaces(
     context: Context,
     diffReport: DiffReport,
 ): Promise<void> {
     const workspaces = context.project.workspaces
+    const resolvedVersionsFromNodeModules = await maybeResolvePackageVersionsFromNodeModules(
+        context,
+    )
     console.log(`Attempting to fix ${workspaces.length} packages`)
     await Promise.all(
         workspaces.map(
@@ -21,6 +28,7 @@ export default async function fixWorkspaces(
                 fixWorkspace(
                     context,
                     workspace,
+                    resolvedVersionsFromNodeModules,
                     diffReport.undeclared.get(workspaceIdent) ?? new Set(),
                     diffReport.unused.get(workspaceIdent) ?? new Set(),
                 )
@@ -32,6 +40,7 @@ export default async function fixWorkspaces(
 async function fixWorkspace(
     context: Context,
     workspace: Workspace,
+    resolvedVersionsFromNodeModules: Map<string, string>,
     undeclaredDependencies: Set<string>,
     unusedDependencies: Set<string>,
 ): Promise<void> {
@@ -58,6 +67,17 @@ async function fixWorkspace(
             const dependencyIdent = structUtils.tryParseIdent(dependency)
 
             if (!dependencyIdent) throw new Error('MISSING_DEPENDENCY_IDENT')
+
+            if (resolvedVersionsFromNodeModules.has(dependency)) {
+                dependenciesToAdd.set(
+                    dependencyIdent.identHash,
+                    structUtils.makeDescriptor(
+                        dependencyIdent,
+                        `^${resolvedVersionsFromNodeModules.get(dependency)}`,
+                    ),
+                )
+                continue
+            }
 
             const identUrl = npmHttpUtils.getIdentUrl(dependencyIdent)
             const distTagUrl = `/-/package${identUrl}/dist-tags`
@@ -96,4 +116,47 @@ async function fixWorkspace(
         ),
     )
     await workspace.persistManifest()
+}
+
+/*
+ * Resolver for node_modules, crawls upwards from cwd to find any node_modules that
+ * could be picked up at runtime and collects versions. The closest version available
+ * for a given package is the resolved one.
+ */
+async function maybeResolvePackageVersionsFromNodeModules(
+    context: Context,
+): Promise<PackageResolutions> {
+    const resolutions: PackageResolutions = new Map()
+
+    const cwd = context.cwd
+    const stepsBack = path.resolve(cwd).split(path.sep)
+
+    while (stepsBack.length > 0) {
+        stepsBack.pop()
+
+        const currentPath = stepsBack.join(path.sep) || path.sep
+        const surroundings = await fs.readdir(currentPath)
+
+        if (surroundings.includes('node_modules')) {
+            const modulePath = path.resolve(currentPath, 'node_modules')
+            const moduleDirs = await fs.readdir(modulePath)
+
+            for (const moduleDir of moduleDirs) {
+                if (moduleDir.startsWith('.')) continue
+                const manifest = await Manifest.find(
+                    path.resolve(modulePath, moduleDir) as PortablePath,
+                )
+                if (!manifest.name) continue
+                const packageName = structUtils.stringifyIdent(manifest.name)
+                if (
+                    manifest.version &&
+                    packageName &&
+                    !resolutions.has(packageName)
+                )
+                    resolutions.set(packageName, manifest.version)
+            }
+        }
+    }
+
+    return resolutions
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,8 @@ export interface AnalysisConfiguration {
 
 export type PackagesByWorkspaceMap = Map<Workspace, Set<string>>
 
+export type PackageResolutions = Map<string, string>
+
 export interface Arguments {
     cwd?: string
     include?: string[]

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,11 +6,6 @@ export interface Context {
     cwd: string
 }
 
-export interface PartialAnalysisConfiguration {
-    include?: Set<string>
-    exclude?: Set<string>
-}
-
 export interface AnalysisConfiguration {
     include: Set<string>
     exclude: Set<string>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,12 +5,7 @@ import { Configuration, Project } from '@yarnpkg/core'
 import { getPluginConfiguration } from '@yarnpkg/cli'
 import { PortablePath } from '@yarnpkg/fslib'
 
-import {
-    AnalysisConfiguration,
-    Arguments,
-    Context,
-    PartialAnalysisConfiguration,
-} from './types'
+import { AnalysisConfiguration, Arguments, Context } from './types'
 
 export async function getConfiguration(
     args: Arguments,
@@ -49,7 +44,7 @@ function getFullCwd(cwd?: string): string {
 
 async function maybeGetConfigurationFromFile(
     cwd: string,
-): Promise<PartialAnalysisConfiguration> {
+): Promise<Partial<AnalysisConfiguration>> {
     try {
         const configurationFromFile = await fs.readFile(
             resolve(cwd, '.ghostImports.json'),

--- a/tests/testUtils.ts
+++ b/tests/testUtils.ts
@@ -4,8 +4,12 @@ import { dirname, resolve } from 'path'
 
 export const TEST_PACKAGE_NAME = 'testpackage'
 
-export async function cleanUp(rootPath: string): Promise<void> {
-    await fs.rmdir(rootPath, { recursive: true })
+export async function cleanUp(paths: string[]): Promise<void> {
+    await Promise.all(
+        paths.map(async (tempPath) =>
+            fs.rmdir(tempPath, { recursive: true, force: true }),
+        ),
+    )
 }
 
 export async function prepareTempDirectory(
@@ -91,6 +95,10 @@ export async function declareDependencies(
     await createFile(cwd, 'package.json', JSON.stringify(currentPackageJson))
 
     return currentPackageJson
+}
+
+export async function readFile(path: string): string {
+    return fs.readFile(path, { encoding: 'utf8' })
 }
 
 export async function createFile(


### PR DESCRIPTION
This PR makes autofixing better by adding a step that tries to resolve package versions to something close(r) to what node normally sees. Going from `cwd`, we go up the file system tree until we reach the file system root and at each step, we look for a `node_modules` directory. If we find it, we accumulate the versions from package manifests contained in that directory. The version of a given package that's defined in the `node_modules` closest to `cwd` is the one that gets picked as it would likely be the resolution from node. This resolution runs before workspace fixing starts.

## AuthorQA

- Tried out a couple of local repos with `node_modules` set up at different spots between there and the fs root.
- [x] Ensures that the resolved version for undeclared packages was the one from the `node_modules`.