### PR TITLE
test: add cov for config file incl./excl.

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -93,7 +93,6 @@ async function maybeGetConfigurationFromFile(
         )
         // eslint-disable-next-line @typescript-eslint/no-var-requires
         const configuration = require(configurationFilePath) || {}
-
         const { includeFiles, excludeFiles, excludePackages } = configuration
         const includeFilesFromConfig =
             typeof includeFiles === 'function'
@@ -109,7 +108,7 @@ async function maybeGetConfigurationFromFile(
                 : (filename: string): boolean =>
                       excludeFiles?.some?.((pattern: string) =>
                           minimatch(filename, pattern),
-                      ) ?? true
+                      ) ?? false
 
         const excludePackagesFromConfig =
             typeof excludePackages === 'function'

--- a/tests/configuration.test.ts
+++ b/tests/configuration.test.ts
@@ -3,6 +3,90 @@ import validateDependencies from '../src'
 import { createFile, withMonorepoContext } from './testUtils'
 
 describe('Configuration', () => {
+    describe('via config file', () => {
+        it('includes can be supplied via config file', async () =>
+            await withMonorepoContext(
+                {
+                    root: {},
+                    'pkg-1': { dependencies: ['pkg-2'] },
+                    'pkg-2': {},
+                },
+                async (tempRoot) => {
+                    const packageRoot = `${tempRoot}/packages/pkg-1/`
+                    await createFile(
+                        packageRoot,
+                        'index.js',
+                        `
+                     const { foo } = require("pkg-2")
+                     foo()`,
+                    )
+                    await createFile(
+                        packageRoot,
+                        'ghost-imports.config.js',
+                        `
+                module.exports = {
+                    includeFiles: ["**/index.js"]
+                }
+                    `,
+                    )
+
+                    // The includelist includes the file above, pkg-1 is declared and used.
+                    const report = await validateDependencies({
+                        cwd: packageRoot,
+                    })
+                    console.log(report)
+                    if (!report) throw new Error('No report produced')
+                    expect(
+                        report.undeclaredDependencies?.get('pkg-1')?.size,
+                    ).toEqual(0)
+                    expect(
+                        report.unusedDependencies.get('pkg-1')?.size,
+                    ).toEqual(0)
+                },
+            ))
+        it('excludes can be supplied via config file', async () =>
+            await withMonorepoContext(
+                {
+                    root: {},
+                    'pkg-1': { dependencies: ['pkg-2'] },
+                    'pkg-2': {},
+                },
+                async (tempRoot) => {
+                    const packageRoot = `${tempRoot}/packages/pkg-1/`
+                    // This file will be excluded and ignored.
+                    await createFile(
+                        packageRoot,
+                        'index.js',
+                        `
+                     const { foo } = require("pkg-2")
+                     foo()`,
+                    )
+                    await createFile(
+                        packageRoot,
+                        'ghost-imports.config.js',
+                        `
+                module.exports = {
+                    excludeFiles: ["**/index.js"]
+                }
+                    `,
+                    )
+
+                    // The includelist includes the file above, pkg-1 is declared and used.
+                    const report = await validateDependencies({
+                        cwd: packageRoot,
+                    })
+                    console.log(report)
+                    if (!report) throw new Error('No report produced')
+                    expect(
+                        report.undeclaredDependencies?.get('pkg-1')?.size,
+                    ).toEqual(0)
+                    expect(report.unusedDependencies.get('pkg-1')).toEqual(
+                        new Set(['pkg-2']),
+                    )
+                },
+            ))
+    })
+
     it('excludes specified "excluded" globs', async () =>
         await withMonorepoContext(
             {


### PR DESCRIPTION
- Fixes the default for config file `excludeFiles` -- when unsupplied, previously always returned `true`, which excluded everything.
- Adds coverage for incl./excl. supplied via config file.