### PR TITLE
refactor: faster globbing

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@yarnpkg/plugin-npm": "^2.4.0",
     "@yarnpkg/plugin-pack": "^2.2.3",
     "chalk": "^4.1.0",
-    "minimatch": "^3.0.4",
+    "fast-glob": "^3.2.5",
     "yargs": "^16.2.0"
   },
   "lint-staged": {

--- a/src/diffDependenciesAndImportsByWorkspace.ts
+++ b/src/diffDependenciesAndImportsByWorkspace.ts
@@ -76,13 +76,13 @@ async function getUndeclaredDependencies(
 
         if (
             dependenciesMap.devDependencies.has(identHash) &&
-            devFiles.includes(importedFrom) //configuration.devFiles(importedFrom)
+            devFiles.includes(importedFrom)
         )
             continue
 
         if (
             dependenciesMap.peerDependencies.has(identHash) &&
-            !devFiles.includes(importedFrom) //configuration.devFiles(importedFrom)
+            !devFiles.includes(importedFrom)
         )
             continue
 
@@ -109,11 +109,7 @@ async function getUnusedDependencies(
         cwd: workspace.cwd,
     })
     for (const { imported, importedFrom } of imports.values()) {
-        if (
-            devFiles.includes(
-                importedFrom,
-            ) /*configuration.devFiles(importedFrom)*/
-        ) {
+        if (devFiles.includes(importedFrom)) {
             const devSet = devImportsUsage.get(imported) ?? new Set<string>()
             devImportsUsage.set(imported, devSet)
             devSet.add(importedFrom)

--- a/src/diffDependenciesAndImportsByWorkspace.ts
+++ b/src/diffDependenciesAndImportsByWorkspace.ts
@@ -1,4 +1,5 @@
 import { Workspace, structUtils } from '@yarnpkg/core'
+import fastGlob from 'fast-glob'
 
 import {
     AnalysisConfiguration,
@@ -9,12 +10,12 @@ import {
     ImportRecordsByWorkspaceMap,
 } from './types'
 
-export default function diffDependenciesAndImportsByWorkspace(
+export default async function diffDependenciesAndImportsByWorkspace(
     context: Context,
     configuration: AnalysisConfiguration,
     dependenciesMap: Map<Workspace, DependenciesMap>,
     importsMap: ImportRecordsByWorkspaceMap,
-): DiffReport {
+): Promise<DiffReport> {
     const { workspaces } = context.project
     const undeclaredDependenciesMap = new Map()
     const unusedDependenciesMap = new Map()
@@ -30,12 +31,13 @@ export default function diffDependenciesAndImportsByWorkspace(
 
         if (!workspaceDependencies || !workspaceImports) continue
 
-        const undeclaredDependencies = getUndeclaredDependencies(
+        const undeclaredDependencies = await getUndeclaredDependencies(
             configuration,
+            workspace,
             workspaceDependencies,
             workspaceImports,
         )
-        const unusedDependencies = getUnusedDependencies(
+        const unusedDependencies = await getUnusedDependencies(
             configuration,
             workspace,
             workspaceDependencies,
@@ -52,13 +54,16 @@ export default function diffDependenciesAndImportsByWorkspace(
     }
 }
 
-function getUndeclaredDependencies(
+async function getUndeclaredDependencies(
     configuration: AnalysisConfiguration,
+    workspace: Workspace,
     dependenciesMap: DependenciesMap,
     imports: Set<ImportRecord>,
-): Set<string> {
+): Promise<Set<string>> {
     const undeclaredDependencies: Set<string> = new Set()
-
+    const devFiles = await fastGlob(configuration.devFiles, {
+        cwd: workspace.cwd,
+    })
     for (const { imported, importedFrom } of imports) {
         const importedIdent = structUtils.parseIdent(imported)
         const identHash = importedIdent.identHash
@@ -71,13 +76,13 @@ function getUndeclaredDependencies(
 
         if (
             dependenciesMap.devDependencies.has(identHash) &&
-            configuration.devFiles(importedFrom)
+            devFiles.includes(importedFrom) //configuration.devFiles(importedFrom)
         )
             continue
 
         if (
             dependenciesMap.peerDependencies.has(identHash) &&
-            !configuration.devFiles(importedFrom)
+            !devFiles.includes(importedFrom) //configuration.devFiles(importedFrom)
         )
             continue
 
@@ -90,19 +95,25 @@ function getUndeclaredDependencies(
 // TODO
 //function getMovableDependencies(): void {}
 
-function getUnusedDependencies(
+async function getUnusedDependencies(
     configuration: AnalysisConfiguration,
     workspace: Workspace,
     dependenciesMap: DependenciesMap,
     imports: Set<ImportRecord>,
-): Set<string> {
+): Promise<Set<string>> {
     const unusedDependencies: Set<string> = new Set()
 
     const importsUsage = new Map<string, Set<string>>()
     const devImportsUsage = new Map<string, Set<string>>()
-
+    const devFiles = await fastGlob(configuration.devFiles, {
+        cwd: workspace.cwd,
+    })
     for (const { imported, importedFrom } of imports.values()) {
-        if (configuration.devFiles(importedFrom)) {
+        if (
+            devFiles.includes(
+                importedFrom,
+            ) /*configuration.devFiles(importedFrom)*/
+        ) {
             const devSet = devImportsUsage.get(imported) ?? new Set<string>()
             devImportsUsage.set(imported, devSet)
             devSet.add(importedFrom)

--- a/src/getImportsFromWorkspaceMap.ts
+++ b/src/getImportsFromWorkspaceMap.ts
@@ -142,17 +142,7 @@ async function* collectPaths(
     configuration: AnalysisConfiguration,
     workspace: Workspace,
 ): AsyncIterable<string> {
-    //const basename = path.basename(filename)
-    //const stat = await fs.stat(filename)
-
-    /*const excludes = configuration.excludeFiles.map(
-        (patt: string) => `!${patt}`,
-    )*/
-    const includes = configuration.includeFiles
-
-    const patterns = [...includes]
-
-    const paths = await fastGlob(patterns, {
+    const paths = await fastGlob(configuration.includeFiles, {
         absolute: true,
         ignore: configuration.excludeFiles,
         cwd: workspace.cwd,
@@ -160,7 +150,9 @@ async function* collectPaths(
 
     for (const filepath of paths) {
         const basename = path.basename(filepath)
+        // Exclude if dotfile.
         if (basename.startsWith('.')) continue
+        // Exclude if not part of the current workspace.
         const discoveredWorkspace = workspace.project.tryWorkspaceByFilePath(
             npath.toPortablePath(filepath),
         )
@@ -172,43 +164,7 @@ async function* collectPaths(
             )
         )
             continue
+        // Include if ts/js source.
         if (basename.match(/\.(j|t)sx?$/)) yield filepath
     }
-    /*
-    if (basename.startsWith('.')) return
-
-    if (
-        !stat.isDirectory() &&
-        (!configuration.includeFiles(filename) ||
-            configuration.excludeFiles(filename))
-    ) {
-        return
-    }
-
-    // if dir belongs to another workspace, don't return any files
-    const discoveredWorkspace = workspace.project.tryWorkspaceByFilePath(
-        npath.toPortablePath(filename),
-    )
-    if (
-        !discoveredWorkspace ||
-        !structUtils.areDescriptorsEqual(
-            discoveredWorkspace.anchoredDescriptor,
-            workspace.anchoredDescriptor,
-        )
-    ) {
-        return
-    }
-
-    if (stat.isDirectory()) {
-        for (const childFilename of await fs.readdir(filename)) {
-            yield* collectPaths(
-                configuration,
-                workspace,
-                path.join(filename, childFilename),
-            )
-        }
-    } else if (basename.match(/\.(j|t)sx?$/)) {
-        yield filename
-    }
-    */
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ export default async function validateDependencies(
     const importsMap = await getImportsByWorkspaceMap(context, configuration)
 
     // Diff dependencies and imports by workspace
-    const diffReport = diffDependenciesAndImportsByWorkspace(
+    const diffReport = await diffDependenciesAndImportsByWorkspace(
         context,
         configuration,
         dependenciesMap,
@@ -45,7 +45,7 @@ export default async function validateDependencies(
         undeclaredDependencies: diffReport.undeclared,
         unusedDependencies: diffReport.unused,
     }
-
+    console.log(report)
     printReport(report)
     if (configuration.fix) await fixWorkspaces(context, diffReport)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,6 @@ export default async function validateDependencies(
         undeclaredDependencies: diffReport.undeclared,
         unusedDependencies: diffReport.unused,
     }
-    console.log(report)
     printReport(report)
     if (configuration.fix) await fixWorkspaces(context, diffReport)
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,8 +7,6 @@ import {
     Workspace,
 } from '@yarnpkg/core'
 
-export type FileMatchPredicate = (filename: string) => boolean
-
 export type PackageMatchPredicate = (packageName: string) => boolean
 
 export interface Context {
@@ -19,9 +17,9 @@ export interface Context {
 }
 
 export interface AnalysisConfiguration {
-    includeFiles: string[] //FileMatchPredicate
-    excludeFiles: string[] //FileMatchPredicate
-    devFiles: string[] //FileMatchPredicate
+    includeFiles: string[]
+    excludeFiles: string[]
+    devFiles: string[]
     excludePackages: PackageMatchPredicate
     fix: boolean
     skipRoot: boolean

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,9 +19,9 @@ export interface Context {
 }
 
 export interface AnalysisConfiguration {
-    includeFiles: FileMatchPredicate
-    excludeFiles: FileMatchPredicate
-    devFiles: FileMatchPredicate
+    includeFiles: string[] //FileMatchPredicate
+    excludeFiles: string[] //FileMatchPredicate
+    devFiles: string[] //FileMatchPredicate
     excludePackages: PackageMatchPredicate
     fix: boolean
     skipRoot: boolean

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,5 @@
 import { resolve } from 'path'
 
-//import minimatch from 'minimatch'
 import { Configuration, Project, structUtils } from '@yarnpkg/core'
 import { getPluginConfiguration } from '@yarnpkg/cli'
 import { npath } from '@yarnpkg/fslib'
@@ -9,7 +8,6 @@ import {
     AnalysisConfiguration,
     Arguments,
     Context,
-    //    FileMatchPredicate,
     PackageMatchPredicate,
 } from './types'
 
@@ -40,21 +38,6 @@ export async function getConfiguration(
         '**/tests/**',
         '**/*.test.*',
     ]
-    /*
-    const includeFiles: FileMatchPredicate | undefined = includeFilesFromArgs
-        ? (filePath): boolean =>
-              includeFilesFromArgs.some((pattern) =>
-                  minimatch(filePath, pattern),
-              )
-        : includeFilesFromFile
-
-    const excludeFiles: FileMatchPredicate | undefined = excludeFilesFromArgs
-        ? (filePath): boolean =>
-              excludeFilesFromArgs.some((pattern) =>
-                  minimatch(filePath, pattern),
-              )
-        : excludeFilesFromFile
-    */
     const excludePackages:
         | PackageMatchPredicate
         | undefined = excludePackagesFromArgs
@@ -62,18 +45,11 @@ export async function getConfiguration(
               excludePackagesFromArgs.includes(packageName)
         : excludePackagesFromFile
 
-    /*
-    const devFiles: FileMatchPredicate | undefined = devFilesFromArgs
-        ? (filePath): boolean =>
-              devFilesFromArgs.some((pattern) => minimatch(filePath, pattern))
-        : devFilesFromFile
-    */
-
     return {
-        includeFiles, //: includeFiles ?? ((): boolean => true),
-        excludeFiles, //: excludeFiles ?? ((): boolean => false),
+        includeFiles,
+        excludeFiles,
         excludePackages: excludePackages ?? ((): boolean => false),
-        devFiles, //: devFiles ?? ((): boolean => false),
+        devFiles,
         fix: args.fix ?? false,
         skipRoot: args.skipRoot ?? false,
     }
@@ -135,36 +111,6 @@ async function maybeGetConfigurationFromFile(
             excludePackages,
             devFiles,
         } = configuration
-        /*
-        const includeFilesFromConfig =
-            typeof includeFiles === 'function'
-                ? includeFiles
-                : (filename: string): boolean =>
-                      includeFiles?.some?.((pattern: string) =>
-                          minimatch(filename, pattern),
-                      ) ?? true
-
-        const excludeFilesFromConfig =
-            typeof excludeFiles === 'function'
-                ? excludeFiles
-                : (filename: string): boolean =>
-                      excludeFiles?.some?.((pattern: string) =>
-                          minimatch(filename, pattern),
-                      ) ?? false
-                     */
-
-        //const defaultDevFiles = (filename: string): boolean =>
-        //   ['**/__tests__/**', '**/tests/**', '**/*.test.*'].some((pattern) =>
-        //      minimatch(filename, pattern),
-        //  )
-
-        //const devFilesFromConfig =
-        //   typeof devFiles === 'function'
-        //        ? devFiles
-        //       : (filename: string): boolean =>
-        //             devFiles?.some?.((pattern: string) =>
-        //                 minimatch(filename, pattern),
-        //             ) ?? defaultDevFiles(filename)
 
         const excludePackagesFromConfig =
             typeof excludePackages === 'function'
@@ -173,10 +119,10 @@ async function maybeGetConfigurationFromFile(
                       excludePackages?.includes?.(filename) ?? false
 
         return {
-            includeFiles, //: includeFilesFromConfig,
-            excludeFiles, //: excludeFilesFromConfig,
+            includeFiles,
+            excludeFiles,
             excludePackages: excludePackagesFromConfig,
-            devFiles, //: devFilesFromConfig,
+            devFiles,
         }
     } catch (e) {
         /* Configuration unavailable */

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
 import { resolve } from 'path'
 
-import minimatch from 'minimatch'
+//import minimatch from 'minimatch'
 import { Configuration, Project, structUtils } from '@yarnpkg/core'
 import { getPluginConfiguration } from '@yarnpkg/cli'
 import { npath } from '@yarnpkg/fslib'
@@ -9,7 +9,7 @@ import {
     AnalysisConfiguration,
     Arguments,
     Context,
-    FileMatchPredicate,
+    //    FileMatchPredicate,
     PackageMatchPredicate,
 } from './types'
 
@@ -31,6 +31,16 @@ export async function getConfiguration(
     const excludePackagesFromArgs = args.excludePackages
     const devFilesFromArgs = args.devFiles
 
+    const includeFiles = (includeFilesFromArgs || includeFilesFromFile) ?? [
+        '**/*',
+    ]
+    const excludeFiles = (excludeFilesFromArgs || excludeFilesFromFile) ?? []
+    const devFiles = (devFilesFromArgs || devFilesFromFile) ?? [
+        '**/__tests__/**',
+        '**/tests/**',
+        '**/*.test.*',
+    ]
+    /*
     const includeFiles: FileMatchPredicate | undefined = includeFilesFromArgs
         ? (filePath): boolean =>
               includeFilesFromArgs.some((pattern) =>
@@ -44,7 +54,7 @@ export async function getConfiguration(
                   minimatch(filePath, pattern),
               )
         : excludeFilesFromFile
-
+    */
     const excludePackages:
         | PackageMatchPredicate
         | undefined = excludePackagesFromArgs
@@ -52,16 +62,18 @@ export async function getConfiguration(
               excludePackagesFromArgs.includes(packageName)
         : excludePackagesFromFile
 
+    /*
     const devFiles: FileMatchPredicate | undefined = devFilesFromArgs
         ? (filePath): boolean =>
               devFilesFromArgs.some((pattern) => minimatch(filePath, pattern))
         : devFilesFromFile
+    */
 
     return {
-        includeFiles: includeFiles ?? ((): boolean => true),
-        excludeFiles: excludeFiles ?? ((): boolean => false),
+        includeFiles, //: includeFiles ?? ((): boolean => true),
+        excludeFiles, //: excludeFiles ?? ((): boolean => false),
         excludePackages: excludePackages ?? ((): boolean => false),
-        devFiles: devFiles ?? ((): boolean => false),
+        devFiles, //: devFiles ?? ((): boolean => false),
         fix: args.fix ?? false,
         skipRoot: args.skipRoot ?? false,
     }
@@ -123,6 +135,7 @@ async function maybeGetConfigurationFromFile(
             excludePackages,
             devFiles,
         } = configuration
+        /*
         const includeFilesFromConfig =
             typeof includeFiles === 'function'
                 ? includeFiles
@@ -138,19 +151,20 @@ async function maybeGetConfigurationFromFile(
                       excludeFiles?.some?.((pattern: string) =>
                           minimatch(filename, pattern),
                       ) ?? false
+                     */
 
-        const defaultDevFiles = (filename: string): boolean =>
-            ['**/__tests__/**', '**/tests/**', '**/*.test.*'].some((pattern) =>
-                minimatch(filename, pattern),
-            )
+        //const defaultDevFiles = (filename: string): boolean =>
+        //   ['**/__tests__/**', '**/tests/**', '**/*.test.*'].some((pattern) =>
+        //      minimatch(filename, pattern),
+        //  )
 
-        const devFilesFromConfig =
-            typeof devFiles === 'function'
-                ? devFiles
-                : (filename: string): boolean =>
-                      devFiles?.some?.((pattern: string) =>
-                          minimatch(filename, pattern),
-                      ) ?? defaultDevFiles(filename)
+        //const devFilesFromConfig =
+        //   typeof devFiles === 'function'
+        //        ? devFiles
+        //       : (filename: string): boolean =>
+        //             devFiles?.some?.((pattern: string) =>
+        //                 minimatch(filename, pattern),
+        //             ) ?? defaultDevFiles(filename)
 
         const excludePackagesFromConfig =
             typeof excludePackages === 'function'
@@ -159,10 +173,10 @@ async function maybeGetConfigurationFromFile(
                       excludePackages?.includes?.(filename) ?? false
 
         return {
-            includeFiles: includeFilesFromConfig,
-            excludeFiles: excludeFilesFromConfig,
+            includeFiles, //: includeFilesFromConfig,
+            excludeFiles, //: excludeFilesFromConfig,
             excludePackages: excludePackagesFromConfig,
-            devFiles: devFilesFromConfig,
+            devFiles, //: devFilesFromConfig,
         }
     } catch (e) {
         /* Configuration unavailable */

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -142,7 +142,6 @@ describe('GhostImports', () => {
                     const report = await validateDependencies({
                         cwd: projectRoot,
                     })
-
                     expect(
                         report.unusedDependencies.get('pkg-1')?.size,
                     ).toEqual(0)

--- a/yarn.lock
+++ b/yarn.lock
@@ -4198,7 +4198,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-glob@npm:^3.1.1, fast-glob@npm:^3.2.2":
+"fast-glob@npm:^3.1.1, fast-glob@npm:^3.2.2, fast-glob@npm:^3.2.5":
   version: 3.2.5
   resolution: "fast-glob@npm:3.2.5"
   dependencies:
@@ -4577,10 +4577,10 @@ __metadata:
     eslint-plugin-import: ^2.18.2
     eslint-plugin-jest: ^23.0.4
     eslint-plugin-prettier: ^3.1.1
+    fast-glob: ^3.2.5
     husky: ^5.1.1
     jest: ^26.6.3
     lint-staged: ^10.5.4
-    minimatch: ^3.0.4
     mock-fs: ^4.10.4
     packwatch: ^1.0.0
     prettier: ^2.2.1


### PR DESCRIPTION
This removes a lot of weight from the logic that finds source files by using `fastglob` and getting all globs from the root path instead of traversing down to filetree leaves. The conditions are otherwise unchanged.

This is heaps faster than the previous approach.