### PR TITLE
wip: improve fixer, add always peer config option

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,7 @@ export interface AnalysisConfiguration {
     excludePackages: PackageMatchPredicate
     fix: boolean
     skipRoot: boolean
+    alwaysPeerDependencies: PackageMatchPredicate
 }
 
 export interface ImportRecord {
@@ -43,6 +44,10 @@ export interface DependenciesMap {
 
 export type PackageResolutions = Map<string, string>
 
+export type DependencyNameToSetType = Map<
+    string,
+    'dependencies' | 'devDependencies' | 'peerDependencies'
+>
 export interface Arguments {
     cwd?: string
     includeFiles?: string[]
@@ -51,15 +56,16 @@ export interface Arguments {
     excludePackages?: string[]
     fix?: boolean
     skipRoot?: boolean
+    alwaysPeerDependencies?: string[]
 }
 
 export interface DiffReport {
-    undeclared: Map<string, Set<string>>
+    undeclared: Map<string, DependencyNameToSetType>
     unused: Map<string, Set<string>>
 }
 
 export interface Report {
     workspaces: Set<string>
     unusedDependencies: Map<string, Set<string>>
-    undeclaredDependencies: Map<string, Set<string>>
+    undeclaredDependencies: Map<string, DependencyNameToSetType>
 }


### PR DESCRIPTION
Example config from an internal monorepo:

```
module.exports = {
    excludeFiles: ["**/lib/**", "**/docs/**"],
    devFiles: ["**/*.test.{js,jsx,ts,tsx}"],
    alwaysPeerDependencies: [
        'react',
        'react-dom',
        'prop-types',
        'axios',
        'immutable',
        'styled-components',
        'react-redux',
        'redux-saga',
        'react-redux',
    ],
}
```

and run with: `yarn ghost-imports-buster --skipRoot --fix`.